### PR TITLE
Add training log table and trainer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ gem 'activerecord'
 gem 'pg'
 gem 'rake'
 gem 'ejson'
+gem 'news_scraper'
+
+gem 'mocha'
+gem 'minitest'
+gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,11 +14,41 @@ GEM
       tzinfo (~> 1.1)
     arel (7.1.1)
     concurrent-ruby (1.0.2)
+    crass (1.0.2)
     ejson (1.0.1)
+    guess_html_encoding (0.0.11)
+    htmlbeautifier (1.2.0)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
+    metaclass (0.0.4)
+    mini_portile2 (2.1.0)
     minitest (5.9.0)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_xml (0.5.5)
+    news_scraper (0.1.0)
+      htmlbeautifier (~> 1.1, >= 1.1.1)
+      httparty (~> 0.14, >= 0.14.0)
+      nokogiri (~> 1.6, >= 1.6.8)
+      ruby-readability (~> 0.7, >= 0.7.0)
+      sanitize (~> 4.2, >= 4.2.0)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    nokogumbo (1.4.9)
+      nokogiri
     pg (0.18.4)
+    pkg-config (1.1.7)
     rake (11.2.2)
+    ruby-readability (0.7.0)
+      guess_html_encoding (>= 0.0.4)
+      nokogiri (>= 1.6.0)
+    sanitize (4.2.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4.1)
+    sqlite3 (1.3.11)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -29,8 +59,12 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   ejson
+  minitest
+  mocha
+  news_scraper
   pg
   rake
+  sqlite3
 
 BUNDLED WITH
    1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,16 @@
+require 'rake/testtask'
 require 'active_record'
 require 'yaml'
 require 'json'
 
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.pattern = 'test/**/*_test.rb'
+end
+
 namespace :db do
   env = ENV.fetch('ENV', 'development')
-  db_config       = YAML::load(File.open('config/database.yml'))[env]
+  db_config = YAML::load(File.open('config/database.yml'))[env]
   if File.exist?("config/secrets/#{env}.ejson")
     decrypted_text = `ejson decrypt config/secrets/#{env}.ejson`
     db_config.merge!(JSON.parse(decrypted_text))

--- a/bin/train
+++ b/bin/train
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+#
+require_relative '../lib/trainer'
+
+Trainer.train(domain: ENV['DOMAIN'], count: ENV.fetch('NUM', 1))

--- a/db/migrate/20160909021628_create_training_log.rb
+++ b/db/migrate/20160909021628_create_training_log.rb
@@ -1,4 +1,4 @@
-class TrainingLog < ActiveRecord::Migration[5.0]
+class CreateTrainingLog < ActiveRecord::Migration[5.0]
   def up
     create_table :training_logs do |t|
       t.string :root_domain, index: true
@@ -9,7 +9,7 @@ class TrainingLog < ActiveRecord::Migration[5.0]
 
     add_index :training_logs, [:root_domain, :trained_status]
     add_index :training_logs, :uri, unique: true
-  end 
+  end
 
   def down
     drop_table :training_logs

--- a/db/migrate/20160918145238_add_null_constraint_to_tables.rb
+++ b/db/migrate/20160918145238_add_null_constraint_to_tables.rb
@@ -1,0 +1,17 @@
+class AddNullConstraintToTables < ActiveRecord::Migration[5.0]
+  def self.up
+    change_column_null :news_articles, :root_domain, false
+    change_column_null :news_articles, :uri, false
+    change_column_null :training_logs, :root_domain, false
+    change_column_null :training_logs, :uri, false
+    change_column_null :training_logs, :trained_status, false
+  end
+
+  def self.down
+    change_column_null :news_articles, :root_domain, true
+    change_column_null :news_articles, :uri, true
+    change_column_null :training_logs, :root_domain, true
+    change_column_null :training_logs, :uri, true
+    change_column_null :training_logs, :trained_status, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160909021628) do
+ActiveRecord::Schema.define(version: 20160918145238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,10 +23,10 @@ ActiveRecord::Schema.define(version: 20160909021628) do
     t.string   "section"
     t.datetime "datetime"
     t.string   "title"
-    t.string   "root_domain"
+    t.string   "root_domain", null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-    t.string   "uri"
+    t.string   "uri",         null: false
     t.index ["author"], name: "index_news_articles_on_author", using: :btree
     t.index ["datetime"], name: "index_news_articles_on_datetime", using: :btree
     t.index ["root_domain"], name: "index_news_articles_on_root_domain", using: :btree
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 20160909021628) do
   end
 
   create_table "training_logs", force: :cascade do |t|
-    t.string   "root_domain"
-    t.string   "uri"
-    t.string   "trained_status", default: "untrained"
+    t.string   "root_domain",                          null: false
+    t.string   "uri",                                  null: false
+    t.string   "trained_status", default: "untrained", null: false
     t.datetime "created_at",                           null: false
     t.datetime "updated_at",                           null: false
     t.index ["root_domain", "trained_status"], name: "index_training_logs_on_root_domain_and_trained_status", using: :btree

--- a/dev.yml
+++ b/dev.yml
@@ -31,3 +31,4 @@ up:
 commands:
   encrypt: bin/encrypt
   prod_sync: ENV=production bundle exec rake db:migrate
+  train: bundle exec bin/train

--- a/lib/models/training_log.rb
+++ b/lib/models/training_log.rb
@@ -1,0 +1,16 @@
+require 'active_record'
+
+class TrainingLog < ActiveRecord::Base
+  validates :uri, uniqueness: true
+  validates :trained_status, inclusion: { in: %w(untrained claimed trained), message: "%{value} is not a valid trained status" }
+
+  class << self
+    def mark_claimed(log)
+      where(root_domain: log.root_domain).update(trained_status: 'claimed')
+    end
+
+    def mark_trained(log)
+      where(root_domain: log.root_domain).update(trained_status: 'trained')
+    end
+  end
+end

--- a/lib/trainer.rb
+++ b/lib/trainer.rb
@@ -1,0 +1,46 @@
+require 'news_scraper'
+require 'active_record'
+require_relative 'models/training_log'
+
+class Trainer
+  class << self
+    def train(domain: nil, count: 1)
+      training_log_params = { trained_status: 'untrained' }
+      training_log_params.merge(root_domain: domain) if domain
+
+      connect_to_database
+
+      training_logs = TrainingLog.where(training_log_params).limit(count)
+      puts "#{training_logs.count} training logs found."
+
+      training_logs.each do |log|
+        cli_train(log)
+      end
+    end
+
+    private
+
+    def cli_train(log)
+      TrainingLog.mark_claimed(log)
+      sleep 1
+
+      url_trainer = NewsScraper::Trainer::UrlTrainer.new(log.uri)
+      url_trainer.train
+
+      TrainingLog.mark_trained(log)
+    end
+
+    # TODO: default to production?
+    def connect_to_database
+      env = ENV.fetch('ENV', 'development')
+      db_config = YAML::load(File.open('config/database.yml'))[env]
+      if File.exist?("config/secrets/#{env}.ejson")
+        decrypted_text = `ejson decrypt config/secrets/#{env}.ejson`
+        db_config.merge!(JSON.parse(decrypted_text))
+      end
+      ActiveRecord::Base.logger = Logger.new(File.open('logs/db.log', 'a'))
+      ActiveRecord::Base.establish_connection(db_config)
+    end
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,6 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mocha/mini_test'
+require 'active_record'
+require_relative '../lib/models/training_log'
+require_relative '../lib/trainer'

--- a/test/unit/models/training_log_test.rb
+++ b/test/unit/models/training_log_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class TrainingLogTest < MiniTest::Test
+  def setup
+    capture_subprocess_io do
+      # temp in-memory db for testing ActiveRecord objects
+      ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+      ActiveRecord::Migrator.migrate("db/migrate/")
+    end
+
+    @training_log = TrainingLog.create(
+      root_domain: 'example.com',
+      uri: 'example.com/article',
+      trained_status: 'untrained'
+    )
+  end
+
+  def test_mark_claimed_sets_trained_status_as_claimed
+    TrainingLog.mark_claimed(@training_log)
+
+    assert_equal 'claimed', @training_log.reload.trained_status
+  end
+
+  def test_mark_trained_sets_trained_status_as_trained
+    TrainingLog.mark_trained(@training_log)
+
+    assert_equal 'trained', @training_log.reload.trained_status
+  end
+end

--- a/test/unit/trainer_test.rb
+++ b/test/unit/trainer_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class TrainerTest < MiniTest::Test
+  def setup
+    capture_subprocess_io do
+      # temp in-memory db for testing ActiveRecord objects
+      ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+      ActiveRecord::Migrator.migrate("db/migrate/")
+    end
+
+    ActiveRecord::Base.expects(:establish_connection).returns(true)
+  end
+
+  def test_train_prompts_cli_when_there_are_untrained_training_logs
+    training_log = TrainingLog.create(
+      root_domain: 'example.com',
+      uri: 'example.com/article'
+    )
+    Trainer.expects(:cli_train).with(training_log)
+
+    capture_subprocess_io do
+      Trainer.train(domain: 'example.com')
+    end
+  end
+
+  def test_train_finds_first_untrained_training_log_if_no_domain_specified
+    training_log = TrainingLog.create(
+      root_domain: 'example.com',
+      uri: 'example.com/article'
+    )
+    Trainer.expects(:cli_train).with(training_log)
+
+    capture_subprocess_io do
+      Trainer.train
+    end
+  end
+
+  def test_train_can_query_and_step_through_multiple_training_logs
+    expected_logs = [
+      TrainingLog.create(root_domain: 'example1.com', uri: 'example1.com/article'),
+      TrainingLog.create(root_domain: 'example2.com', uri: 'example2.com/article')
+    ]
+
+    Trainer.expects(:cli_train).with(expected_logs[0])
+    Trainer.expects(:cli_train).with(expected_logs[1])
+
+    capture_subprocess_io do
+      Trainer.train(count: 2)
+    end
+  end
+
+  def test_train_does_not_prompt_for_claimed_or_trained_training_logs
+    TrainingLog.create( root_domain: 'example.com', uri: 'example.com/article', trained_status: 'claimed')
+    TrainingLog.create( root_domain: 'example.com', uri: 'example.com/article', trained_status: 'trained')
+
+    TrainingLog.expects(:cli_train).never
+
+    capture_subprocess_io do
+      Trainer.train
+    end
+  end
+end


### PR DESCRIPTION
## What this does
- Adds a 'TrainingLog` table
- You can see the intended flow in `bin/train`
- The idea is that our respective apps would log a "TrainingLog" or something and then we can each train the uris that need to be trained. If there is already a log for a domain, add the URI to the array - might be useful in the future
- This will let us collaborate and not walk on each other's toes when training domains.

_This is not done, but I wanted feedback before continuing_
- If I were to continue, I'd actually add the newscraper (failing because of https://github.com/richardwu/news_scraper/issues/17)
- Add some tests
- etc

cc @richardwu
