### PR TITLE
[Thought/Prototype] Domains in the database

### DIFF
--- a/db/migrate/20160917235742_create_domains_table.rb
+++ b/db/migrate/20160917235742_create_domains_table.rb
@@ -1,0 +1,12 @@
+class CreateDomainsTable < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :domains do |t|
+      t.string :root_domain, null: false
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :domains
+  end
+end

--- a/db/migrate/20160917235917_create_domain_entries_table.rb
+++ b/db/migrate/20160917235917_create_domain_entries_table.rb
@@ -1,0 +1,17 @@
+class CreateDomainEntriesTable < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :domain_entries do |t|
+      t.string :key
+      t.string :method
+      t.string :pattern
+      t.integer :domain_id, null: false
+      t.timestamps
+    end
+    add_foreign_key :domain_entries, :domains
+  end
+
+  def self.down
+    remove_foreign_key :domain_entries, :domains
+    drop_table :domain_entries
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160909021628) do
+ActiveRecord::Schema.define(version: 20160917235917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "domain_entries", force: :cascade do |t|
+    t.string   "key"
+    t.string   "method"
+    t.string   "pattern"
+    t.integer  "domain_id",  null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "domains", force: :cascade do |t|
+    t.string   "root_domain", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "news_articles", force: :cascade do |t|
     t.string   "author"
@@ -46,4 +61,5 @@ ActiveRecord::Schema.define(version: 20160909021628) do
     t.index ["uri"], name: "index_training_logs_on_uri", unique: true, using: :btree
   end
 
+  add_foreign_key "domain_entries", "domains"
 end


### PR DESCRIPTION
## Problem
- Domains are currently stored in the gem's `article_scrape_patterns.yml` file.
- This means that to get newly trained articles, you need to commit the domains that are changed to the gem, push, and then bump the gem in all apps.
- We could write the domains to disk for each app instead of relying on the gem's scrape patterns - but that comes down to the same issue - we don't have access to write to all apps so the process is quite manual and not instant.
- The problem with this not being instant is that if you train domain `example.com` and then I encounter `example.com` before things are pushed and synced - then we have a problem as I'll make a new untrained entry.
## Proposal
- Store domains in this `domains` and `domain_entries` table
- Our apps read from this. We can auto-generate a domains entry that we can periodically sync to the gem

cc @richardwu 
